### PR TITLE
foojank: Remove HideHelpCommand in subcommands

### DIFF
--- a/internal/foojank/commands/agent/root.go
+++ b/internal/foojank/commands/agent/root.go
@@ -19,6 +19,5 @@ func NewCommand() *cli.Command {
 			exec.NewCommand(),
 		},
 		CommandNotFound: actions.CommandNotFound,
-		HideHelpCommand: true,
 	}
 }

--- a/internal/foojank/commands/config/generate/root.go
+++ b/internal/foojank/commands/config/generate/root.go
@@ -17,6 +17,5 @@ func NewCommand() *cli.Command {
 			client.NewCommand(),
 		},
 		CommandNotFound: actions.CommandNotFound,
-		HideHelpCommand: true,
 	}
 }

--- a/internal/foojank/commands/config/root.go
+++ b/internal/foojank/commands/config/root.go
@@ -15,6 +15,5 @@ func NewCommand() *cli.Command {
 			generate.NewCommand(),
 		},
 		CommandNotFound: actions.CommandNotFound,
-		HideHelpCommand: true,
 	}
 }

--- a/internal/foojank/commands/repository/root.go
+++ b/internal/foojank/commands/repository/root.go
@@ -23,6 +23,5 @@ func NewCommand() *cli.Command {
 			remove.NewCommand(),
 		},
 		CommandNotFound: actions.CommandNotFound,
-		HideHelpCommand: true,
 	}
 }

--- a/internal/foojank/commands/script/root.go
+++ b/internal/foojank/commands/script/root.go
@@ -17,6 +17,5 @@ func NewCommand() *cli.Command {
 			exec.NewCommand(),
 		},
 		CommandNotFound: actions.CommandNotFound,
-		HideHelpCommand: true,
 	}
 }

--- a/internal/foojank/commands/server/root.go
+++ b/internal/foojank/commands/server/root.go
@@ -15,6 +15,5 @@ func NewCommand() *cli.Command {
 			start.NewCommand(),
 		},
 		CommandNotFound: actions.CommandNotFound,
-		HideHelpCommand: true,
 	}
 }


### PR DESCRIPTION
Fix a bug where commands that only have a single subcommand are not displayed in the help text.

Closes #135 