### PR TITLE
foojank/commands/agent/exec: Add --script (-s) flag

### DIFF
--- a/internal/foojank/flags/flags.go
+++ b/internal/foojank/flags/flags.go
@@ -12,4 +12,5 @@ const (
 	DataDir          = "data-dir"
 	Force            = "force"
 	TLSCACertificate = "tls-ca-certificate"
+	Script           = "script"
 )


### PR DESCRIPTION
This removes support for specifying scripts (+ args) as positional arguments.

Closes #161.