### PR TITLE
go: Temporarily use dnbsd's fork of Risor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	golang.org/x/sync v0.15.0
 )
 
+replace github.com/risor-io/risor => github.com/dnbsd/risor v0.0.0-20250621150513-845711f9fe48
+
 require (
 	github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dnbsd/risor v0.0.0-20250621150513-845711f9fe48 h1:JR5YQnG4VFizGHCWiDDrl9frNxFvmGE6r8EcjI8g8SQ=
+github.com/dnbsd/risor v0.0.0-20250621150513-845711f9fe48/go.mod h1:OuP9WH8h3dzvK7NDfBTA+k095dyTaQxWi/qPTCx3W0g=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/foohq/urlpath v0.1.0 h1:xdqJ2SnLx30ibPl1khWkUDjtab5yE156y3csEEQrBfE=
@@ -58,8 +60,6 @@ github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
 github.com/philhofer/fwd v1.1.2/go.mod h1:qkPdfjR2SIEbspLqpe1tO4n5yICnr2DY7mqEx2tUTP0=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/risor-io/risor v1.8.1 h1:FaycOBo56LudgozpU3FkSBxBgzQJs4GJ4lAno/M2CFo=
-github.com/risor-io/risor v1.8.1/go.mod h1:OuP9WH8h3dzvK7NDfBTA+k095dyTaQxWi/qPTCx3W0g=
 github.com/risor-io/risor/modules/cli v1.8.1 h1:x3J/ggRqxWUJ+D1xRc3Bv+e+LQ+At5xHwNpqWU5AHlY=
 github.com/risor-io/risor/modules/cli v1.8.1/go.mod h1:GJ18omBzt/cHZ0FnTivkcZ7UjE8k5ZrrdWnMpv7ohrI=
 github.com/risor-io/risor/modules/shlex v1.8.1 h1:perzoAlNCsNkW9I4pmtv9ZI2vvKr8mF00An/jFCQk8A=


### PR DESCRIPTION
This fixes upstream bug in VM, which uses filepath to construct import paths. However, path separator used by the importer and OS may be different. This discrepancy breaks import statements on Windows.